### PR TITLE
Fix some input controller issues (mapping sticks and duplicate controller names)

### DIFF
--- a/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -260,7 +260,7 @@ namespace Ryujinx.Input.SDL2
             {
                 if (_buttonsUserMapping.Count == 0)
                     return rawState;
-                
+
 
                 // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
                 foreach (ButtonMappingEntry entry in _buttonsUserMapping)
@@ -291,11 +291,28 @@ namespace Ryujinx.Input.SDL2
             return value * ConvertRate;
         }
 
+        private JoyconConfigControllerStick<GamepadInputId, Common.Configuration.Hid.Controller.StickInputId> GetLogicalJoyStickConfig(StickInputId inputId)
+        {
+            switch (inputId)
+            {
+                case StickInputId.Left:
+                    if (_configuration.RightJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Left)
+                        return _configuration.RightJoyconStick;
+                    else
+                        return _configuration.LeftJoyconStick;
+                case StickInputId.Right:
+                    if (_configuration.LeftJoyconStick.Joystick == Common.Configuration.Hid.Controller.StickInputId.Right)
+                        return _configuration.LeftJoyconStick;
+                    else
+                        return _configuration.RightJoyconStick;
+            }
+            return null;
+        }
+
         public (float, float) GetStick(StickInputId inputId)
         {
             if (inputId == StickInputId.Unbound)
                 return (0.0f, 0.0f);
-            
 
             (short stickX, short stickY) = GetStickXY(inputId);
 
@@ -304,24 +321,22 @@ namespace Ryujinx.Input.SDL2
 
             if (HasConfiguration)
             {
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.InvertStickX) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.InvertStickX))
-                {
-                    resultX = -resultX;
-                }
+                var joyconStickConfig = GetLogicalJoyStickConfig(inputId);
 
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.InvertStickY) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.InvertStickY))
+                if (joyconStickConfig != null)
                 {
-                    resultY = -resultY;
-                }
+                    if (joyconStickConfig.InvertStickX)
+                        resultX = -resultX;
 
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.Rotate90CW) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.Rotate90CW))
-                {
-                    float temp = resultX;
-                    resultX = resultY;
-                    resultY = -temp;
+                    if (joyconStickConfig.InvertStickY)
+                        resultY = -resultY;
+
+                    if (joyconStickConfig.Rotate90CW)
+                    {
+                        float temp = resultX;
+                        resultX = resultY;
+                        resultY = -temp;
+                    }
                 }
             }
 

--- a/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/Input/InputViewModel.cs
@@ -433,12 +433,28 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
 
         public void LoadDevices()
         {
+            string GetGamepadName(IGamepad gamepad, int controllerNumber)
+            {
+                return $"{GetShortGamepadName(gamepad.Name)} ({controllerNumber})";
+            }
+            string GetUniqueGamepadName(IGamepad gamepad, ref int controllerNumber)
+            {
+                string name = GetGamepadName(gamepad, controllerNumber);
+                if (Devices.Any(controller => controller.Name == name))
+                {
+                    controllerNumber++;
+                    name = GetGamepadName(gamepad, controllerNumber);
+                }
+                return name;
+            }
+
             lock (Devices)
             {
                 Devices.Clear();
                 DeviceList.Clear();
                 Devices.Add((DeviceType.None, Disabled, LocaleManager.Instance[LocaleKeys.ControllerSettingsDeviceDisabled]));
 
+                int controllerNumber = 0;
                 foreach (string id in _mainWindow.InputManager.KeyboardDriver.GamepadsIds)
                 {
                     using IGamepad gamepad = _mainWindow.InputManager.KeyboardDriver.GetGamepad(id);
@@ -455,16 +471,10 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
 
                     if (gamepad != null)
                     {
-                        if (Devices.Any(controller => GetShortGamepadId(controller.Id) == GetShortGamepadId(gamepad.Id)))
-                        {
-                            _controllerNumber++;
-                        }
-
-                        Devices.Add((DeviceType.Controller, id, $"{GetShortGamepadName(gamepad.Name)} ({_controllerNumber})"));
+                        string name = GetUniqueGamepadName(gamepad, ref controllerNumber);
+                        Devices.Add((DeviceType.Controller, id, name));
                     }
                 }
-
-                _controllerNumber = 0;
 
                 DeviceList.AddRange(Devices.Select(x => x.Name));
                 Device = Math.Min(Device, DeviceList.Count);
@@ -679,7 +689,7 @@ namespace Ryujinx.Ava.UI.ViewModels.Input
 
                 if (!File.Exists(path))
                 {
-                    var index = ProfilesList.IndexOf(ProfileName);
+                    int index = ProfilesList.IndexOf(ProfileName);
                     if (index != -1)
                     {
                         ProfilesList.RemoveAt(index);


### PR DESCRIPTION
Fix invert x, invert y and rotate when mapping physical left stick to logical right stick and physical right stick to logical left stick

Fix for duplicate controller names under Ava when two controllers of the same type are attached (e.g. two Xbox Controllers)